### PR TITLE
Update library dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.2'
+        classpath 'com.android.tools.build:gradle:1.5.0'
     }
 }
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -4,11 +4,11 @@ version = "1.0.0"
 def code = 22
 
 android {
-    compileSdkVersion 22
+    compileSdkVersion 23
     buildToolsVersion "22.0.1"
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionName version
         versionCode code
     }
@@ -21,7 +21,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:22.1.1'
+    compile 'com.android.support:support-v4:23.1.1'
 }
 
 task sourcesJar(type: Jar) {


### PR DESCRIPTION
- Use SDK ’23’ to as the target SDK compiler
- Update ‘android.tools.build.grade’ to the version ‘1.5.0’
- Update ‘android-support-v4’ library to the version ’23.1.1’
