### PR TITLE
Add synchronization priorities on each Bluetooth Service

### DIFF
--- a/lib/src/androidTest/java/com/sensirion/libble/devices/BleDeviceTest.java
+++ b/lib/src/androidTest/java/com/sensirion/libble/devices/BleDeviceTest.java
@@ -1,0 +1,40 @@
+package com.sensirion.libble.devices;
+
+import android.test.AndroidTestCase;
+import android.test.suitebuilder.annotation.SmallTest;
+
+import com.sensirion.libble.services.BleService;
+import com.sensirion.libble.services.BleServiceSynchronizationPriority;
+import com.sensirion.libble.services.MockBleService;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class BleDeviceTest extends AndroidTestCase {
+
+    /**
+     * Test the {@link BleService} <code>SERVICE_PRIORITY_COMPARATOR</code>
+     */
+    @SmallTest
+    public void testPriorityComparator() {
+        // Creates mock services from different priorities.
+        final BleService testServiceLowPriority =
+                new MockBleService(BleServiceSynchronizationPriority.LOW_PRIORITY);
+        final BleService testServiceNormalPriority =
+                new MockBleService(BleServiceSynchronizationPriority.NORMAL_PRIORITY);
+        final BleService testServiceHighPriority =
+                new MockBleService(BleServiceSynchronizationPriority.HIGH_PRIORITY);
+        // Sorts an unordered Service list using the comparator.
+        final List<BleService> serviceList = Arrays.asList(
+                testServiceNormalPriority,
+                testServiceHighPriority,
+                testServiceLowPriority
+        );
+        Collections.sort(serviceList, MockPeripheral.SERVICE_PRIORITY_COMPARATOR);
+        // Checks if the services are ordered from high to low priority.
+        assertEquals(testServiceHighPriority, serviceList.get(0));
+        assertEquals(testServiceNormalPriority, serviceList.get(1));
+        assertEquals(testServiceLowPriority, serviceList.get(2));
+    }
+}

--- a/lib/src/androidTest/java/com/sensirion/libble/devices/MockPeripheral.java
+++ b/lib/src/androidTest/java/com/sensirion/libble/devices/MockPeripheral.java
@@ -1,0 +1,112 @@
+package com.sensirion.libble.devices;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.sensirion.libble.listeners.NotificationListener;
+import com.sensirion.libble.services.AbstractBleService;
+import com.sensirion.libble.services.AbstractHistoryService;
+import com.sensirion.libble.services.BleService;
+
+class MockPeripheral implements BleDevice {
+
+    @Override
+    public boolean isConnected() {
+        return true;
+    }
+
+    @Override
+    public void connect(@NonNull Context context) {
+    }
+
+    @Override
+    public boolean reconnect() {
+        return true;
+    }
+
+    @Override
+    public void disconnect() {
+    }
+
+    @NonNull
+    @Override
+    public String getAddress() {
+        return "AA:BB:CC:DD:EE:FF";
+    }
+
+    @Nullable
+    @Override
+    public String getAdvertisedName() {
+        return "Advertised Name";
+    }
+
+    @NonNull
+    @Override
+    public DeviceBluetoothType getBluetoothType() {
+        return DeviceBluetoothType.DEVICE_TYPE_UNKNOWN;
+    }
+
+    @Override
+    public int getRSSI() {
+        return 41;
+    }
+
+    @Nullable
+    @Override
+    public <T extends AbstractBleService> T getDeviceService(@NonNull Class<T> type) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public BleService getDeviceService(@NonNull String serviceName) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Iterable<BleService> getDiscoveredServices() {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Iterable<String> getDiscoveredServicesNames() {
+        return null;
+    }
+
+    @Override
+    public int getNumberServices() {
+        return 0;
+    }
+
+    @Override
+    public void setAllNotificationsEnabled(boolean enabled) {
+    }
+
+    @Override
+    public boolean registerDeviceListener(@NonNull NotificationListener listener) {
+        return false;
+    }
+
+    @Override
+    public void unregisterDeviceListener(@NonNull NotificationListener listener) {
+    }
+
+    @Nullable
+    @Override
+    public AbstractHistoryService getHistoryService() {
+        return null;
+    }
+
+    @Override
+    public boolean synchronizeAllDeviceServices() {
+        return true;
+    }
+
+    @Override
+    public boolean areAllServicesReady() {
+        return true;
+    }
+}

--- a/lib/src/androidTest/java/com/sensirion/libble/devices/MockPeripheral.java
+++ b/lib/src/androidTest/java/com/sensirion/libble/devices/MockPeripheral.java
@@ -101,6 +101,11 @@ class MockPeripheral implements BleDevice {
     }
 
     @Override
+    public boolean synchronizeDeviceServices(@NonNull Iterable<BleService> services) {
+        return false;
+    }
+
+    @Override
     public boolean synchronizeAllDeviceServices() {
         return true;
     }

--- a/lib/src/androidTest/java/com/sensirion/libble/services/BleServiceTest.java
+++ b/lib/src/androidTest/java/com/sensirion/libble/services/BleServiceTest.java
@@ -1,0 +1,36 @@
+package com.sensirion.libble.services;
+
+import android.test.AndroidTestCase;
+import android.test.suitebuilder.annotation.SmallTest;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class BleServiceTest extends AndroidTestCase {
+
+    /**
+     * Test {@link BleService#compareTo(BleService)}
+     */
+    @SmallTest
+    public void testCompareTo() {
+        // Creates mock services from different priorities.
+        final BleService testServiceLowPriority =
+                new MockBleService(BleServiceSynchronizationPriority.LOW_PRIORITY);
+        final BleService testServiceNormalPriority =
+                new MockBleService(BleServiceSynchronizationPriority.NORMAL_PRIORITY);
+        final BleService testServiceHighPriority =
+                new MockBleService(BleServiceSynchronizationPriority.HIGH_PRIORITY);
+        // Sorts an unordered Service list using the comparator.
+        final List<BleService> serviceList = Arrays.asList(
+                testServiceNormalPriority,
+                testServiceHighPriority,
+                testServiceLowPriority
+        );
+        Collections.sort(serviceList);
+        // Checks if the services are ordered from high to high priority.
+        assertEquals(testServiceHighPriority, serviceList.get(0));
+        assertEquals(testServiceNormalPriority, serviceList.get(1));
+        assertEquals(testServiceLowPriority, serviceList.get(2));
+    }
+}

--- a/lib/src/androidTest/java/com/sensirion/libble/services/MockBleService.java
+++ b/lib/src/androidTest/java/com/sensirion/libble/services/MockBleService.java
@@ -1,0 +1,84 @@
+package com.sensirion.libble.services;
+
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
+import android.support.annotation.NonNull;
+
+import com.sensirion.libble.listeners.NotificationListener;
+
+import java.util.UUID;
+
+public class MockBleService extends AbstractBleService {
+
+    private final BleServiceSynchronizationPriority mServicePriority;
+
+    public MockBleService() {
+        this(BleServiceSynchronizationPriority.NORMAL_PRIORITY);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    public MockBleService(@NonNull final BleServiceSynchronizationPriority priority) {
+        super(null, null);
+        mServicePriority = priority;
+    }
+
+    @Override
+    public boolean onCharacteristicUpdate(@NonNull BluetoothGattCharacteristic updatedCharacteristic) {
+        return true;
+    }
+
+    @Override
+    public boolean onCharacteristicWrite(@NonNull BluetoothGattCharacteristic characteristic) {
+        return true;
+    }
+
+    @Override
+    public boolean onDescriptorRead(@NonNull BluetoothGattDescriptor descriptor) {
+        return true;
+    }
+
+    @Override
+    public boolean onDescriptorWrite(@NonNull BluetoothGattDescriptor descriptor) {
+        return true;
+    }
+
+    @NonNull
+    @Override
+    public String getUUIDString() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public void setNotificationsEnabled(boolean enabled) {
+    }
+
+    @Override
+    public boolean registerNotificationListener(@NonNull NotificationListener listener) {
+        return true;
+    }
+
+    @Override
+    public boolean unregisterNotificationListener(@NonNull NotificationListener listener) {
+        return true;
+    }
+
+    @Override
+    public boolean isExplicitService(@NonNull String serviceDescription) {
+        return false;
+    }
+
+    @Override
+    public boolean isServiceReady() {
+        return true;
+    }
+
+    @Override
+    public void synchronizeService() {
+    }
+
+    @NonNull
+    @Override
+    public BleServiceSynchronizationPriority getServiceSynchronizationPriority() {
+        return mServicePriority;
+    }
+}

--- a/lib/src/main/java/com/sensirion/libble/devices/BleDevice.java
+++ b/lib/src/main/java/com/sensirion/libble/devices/BleDevice.java
@@ -8,6 +8,11 @@ import com.sensirion.libble.listeners.NotificationListener;
 import com.sensirion.libble.services.AbstractBleService;
 import com.sensirion.libble.services.AbstractHistoryService;
 import com.sensirion.libble.services.BleService;
+import com.sensirion.libble.services.BleServiceSynchronizationPriority;
+
+import java.util.Comparator;
+
+import static com.sensirion.libble.services.BleServiceSynchronizationPriority.HIGH_PRIORITY;
 
 /**
  * Interface for any device that supports Bluetooth Low Energy (BLE)
@@ -156,6 +161,14 @@ public interface BleDevice {
     @SuppressWarnings("unused")
     AbstractHistoryService getHistoryService();
 
+    /**
+     * Tries to synchronize all the device services. Needs to be called periodically. (For example,
+     * every 100ms, until the method returns <code>true</code>.
+     *
+     * @return <code>false</code> if the device is properly synchronized.
+     */
+    @SuppressWarnings("unused")
+    boolean synchronizeAllDeviceServices();
 
     /**
      * Checks if the peripheral has all its services synchronized.
@@ -164,4 +177,18 @@ public interface BleDevice {
      */
     @SuppressWarnings("unused")
     boolean areAllServicesReady();
+
+    /**
+     * Comparator for comparing the different {@link BleService} using their
+     * {@link BleServiceSynchronizationPriority} for comparing them.
+     */
+    @NonNull
+    Comparator<BleService> SERVICE_PRIORITY_COMPARATOR = new Comparator<BleService>() {
+        @Override
+        public int compare(@NonNull final BleService serviceA,
+                           @NonNull final BleService serviceB) {
+            return serviceA.getServiceSynchronizationPriority().ordinal()
+                    - serviceB.getServiceSynchronizationPriority().ordinal();
+        }
+    };
 }

--- a/lib/src/main/java/com/sensirion/libble/devices/BleDevice.java
+++ b/lib/src/main/java/com/sensirion/libble/devices/BleDevice.java
@@ -11,6 +11,7 @@ import com.sensirion.libble.services.BleService;
 import com.sensirion.libble.services.BleServiceSynchronizationPriority;
 
 import java.util.Comparator;
+import java.util.Iterator;
 
 import static com.sensirion.libble.services.BleServiceSynchronizationPriority.HIGH_PRIORITY;
 
@@ -162,10 +163,17 @@ public interface BleDevice {
     AbstractHistoryService getHistoryService();
 
     /**
-     * Tries to synchronize all the device services. Needs to be called periodically. (For example,
-     * every 100ms, until the method returns <code>true</code>.
+     * Tries to synchronize all the input device services. Needs to be called periodically.
+     * (For example, every 100ms, until the method returns <code>true</code>.
      *
      * @return <code>false</code> if the device is properly synchronized.
+     */
+    boolean synchronizeDeviceServices(@NonNull Iterable<BleService> services);
+
+    /**
+     * Tries to synchronize all the device services.
+     *
+     * @see {@link #synchronizeDeviceServices(Iterable))}
      */
     @SuppressWarnings("unused")
     boolean synchronizeAllDeviceServices();

--- a/lib/src/main/java/com/sensirion/libble/devices/Peripheral.java
+++ b/lib/src/main/java/com/sensirion/libble/devices/Peripheral.java
@@ -17,8 +17,10 @@ import com.sensirion.libble.services.AbstractHistoryService;
 import com.sensirion.libble.services.BleService;
 import com.sensirion.libble.services.BleServiceFactory;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
@@ -741,21 +743,31 @@ public class Peripheral implements BleDevice, Comparable<Peripheral> {
      * {@inheritDoc}
      */
     @Override
-    public boolean synchronizeAllDeviceServices() {
-        final List<BleService> servicesToSynchronize = new LinkedList<>(mServices);
+    public boolean synchronizeDeviceServices(@NonNull final Iterable<BleService> services) {
+        final Iterator<BleService> serviceIterator = services.iterator();
+        final List<BleService> serviceToSynchronize = new LinkedList<>();
+        while (serviceIterator.hasNext()) {
+            serviceToSynchronize.add(serviceIterator.next());
+        }
         // Synchronize all the services considering their priorities
-        Collections.sort(servicesToSynchronize, SERVICE_PRIORITY_COMPARATOR);
-        for (final BleService service : servicesToSynchronize) {
+        Collections.sort(serviceToSynchronize, SERVICE_PRIORITY_COMPARATOR);
+        for (final BleService service : serviceToSynchronize) {
             if (!service.isServiceReady()) {
                 // Service is not synchronized yet.
                 service.synchronizeService();
                 return false;
             }
         }
-        // All service are successfully synchronized.
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean synchronizeAllDeviceServices() {
+        return synchronizeDeviceServices(getDiscoveredServices());
+    }
 
     /**
      * {@inheritDoc}

--- a/lib/src/main/java/com/sensirion/libble/devices/Peripheral.java
+++ b/lib/src/main/java/com/sensirion/libble/devices/Peripheral.java
@@ -741,6 +741,26 @@ public class Peripheral implements BleDevice, Comparable<Peripheral> {
      * {@inheritDoc}
      */
     @Override
+    public boolean synchronizeAllDeviceServices() {
+        final List<BleService> servicesToSynchronize = new LinkedList<>(mServices);
+        // Synchronize all the services considering their priorities
+        Collections.sort(servicesToSynchronize, SERVICE_PRIORITY_COMPARATOR);
+        for (final BleService service : servicesToSynchronize) {
+            if (!service.isServiceReady()) {
+                // Service is not synchronized yet.
+                service.synchronizeService();
+                return false;
+            }
+        }
+        // All service are successfully synchronized.
+        return true;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public int compareTo(@Nullable final Peripheral anotherPeripheral) {
         if (isConnected()) {
             return 0;

--- a/lib/src/main/java/com/sensirion/libble/services/AbstractBleService.java
+++ b/lib/src/main/java/com/sensirion/libble/services/AbstractBleService.java
@@ -327,4 +327,13 @@ public abstract class AbstractBleService<ListenerType extends NotificationListen
     public String toString() {
         return String.format("%s of the device: %s", getClass().getSimpleName(), getDeviceAddress());
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int compareTo(@NonNull final BleService otherService) {
+        return otherService.getServiceSynchronizationPriority().ordinal()
+                - getServiceSynchronizationPriority().ordinal();
+    }
 }

--- a/lib/src/main/java/com/sensirion/libble/services/BleService.java
+++ b/lib/src/main/java/com/sensirion/libble/services/BleService.java
@@ -10,7 +10,8 @@ import com.sensirion.libble.listeners.NotificationListener;
  * Represents a {@link android.bluetooth.BluetoothGattService} as defined in org.bluetooth.service.*
  * or a proprietary implementation.
  */
-public interface BleService {
+public interface BleService extends Comparable<BleService> {
+
     /**
      * Method called when a characteristic is read.
      *
@@ -94,4 +95,21 @@ public interface BleService {
      * Tries to synchronize a service in case some of its data is missing.
      */
     void synchronizeService();
+
+    /**
+     * Obtains the service priority towards synchronization.
+     *
+     * @return {@link BleServiceSynchronizationPriority} with the service priority.
+     */
+    @NonNull
+    BleServiceSynchronizationPriority getServiceSynchronizationPriority();
+
+    /**
+     * Compares this object against other {@link BleService} using
+     * their {@link BleServiceSynchronizationPriority}.
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    int compareTo(@NonNull final BleService otherService);
 }

--- a/lib/src/main/java/com/sensirion/libble/services/BleServiceSynchronizationPriority.java
+++ b/lib/src/main/java/com/sensirion/libble/services/BleServiceSynchronizationPriority.java
@@ -1,0 +1,8 @@
+package com.sensirion.libble.services;
+
+/**
+ * Enumerator used to define the synchronization priority of a {@link BleService}
+ */
+public enum BleServiceSynchronizationPriority {
+   LOW_PRIORITY, NORMAL_PRIORITY, HIGH_PRIORITY
+}

--- a/lib/src/main/java/com/sensirion/libble/services/generic/BatteryService.java
+++ b/lib/src/main/java/com/sensirion/libble/services/generic/BatteryService.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import com.sensirion.libble.devices.Peripheral;
 import com.sensirion.libble.listeners.services.BatteryListener;
 import com.sensirion.libble.services.AbstractBleService;
+import com.sensirion.libble.services.BleServiceSynchronizationPriority;
 
 import java.util.Iterator;
 import java.util.concurrent.Executors;
@@ -100,5 +101,14 @@ public class BatteryService extends AbstractBleService<BatteryListener> {
     @Override
     public void registerDeviceCharacteristicNotifications() {
         registerNotification(mBatteryLevelCharacteristic);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public BleServiceSynchronizationPriority getServiceSynchronizationPriority() {
+        return BleServiceSynchronizationPriority.HIGH_PRIORITY;
     }
 }

--- a/lib/src/main/java/com/sensirion/libble/services/generic/DeviceInformationService.java
+++ b/lib/src/main/java/com/sensirion/libble/services/generic/DeviceInformationService.java
@@ -8,6 +8,7 @@ import android.util.Log;
 
 import com.sensirion.libble.devices.Peripheral;
 import com.sensirion.libble.services.AbstractBleService;
+import com.sensirion.libble.services.BleServiceSynchronizationPriority;
 
 public class DeviceInformationService extends AbstractBleService {
 
@@ -267,5 +268,14 @@ public class DeviceInformationService extends AbstractBleService {
             Log.w(TAG, "getSoftwareRevision -> Software revision is not available yet. Requesting it in a background thread");
         }
         return mSoftwareRevision;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public BleServiceSynchronizationPriority getServiceSynchronizationPriority(){
+        return BleServiceSynchronizationPriority.NORMAL_PRIORITY;
     }
 }

--- a/lib/src/main/java/com/sensirion/libble/services/sensirion/shtc1/SHTC1ConnectionSpeedService.java
+++ b/lib/src/main/java/com/sensirion/libble/services/sensirion/shtc1/SHTC1ConnectionSpeedService.java
@@ -8,6 +8,7 @@ import android.util.Log;
 
 import com.sensirion.libble.devices.Peripheral;
 import com.sensirion.libble.services.AbstractBleService;
+import com.sensirion.libble.services.BleServiceSynchronizationPriority;
 
 public class SHTC1ConnectionSpeedService extends AbstractBleService {
 
@@ -128,5 +129,14 @@ public class SHTC1ConnectionSpeedService extends AbstractBleService {
         private CONNECTION_SPEED(final byte value) {
             this.value = value;
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public BleServiceSynchronizationPriority getServiceSynchronizationPriority(){
+        return BleServiceSynchronizationPriority.NORMAL_PRIORITY;
     }
 }

--- a/lib/src/main/java/com/sensirion/libble/services/sensirion/shtc1/SHTC1HistoryService.java
+++ b/lib/src/main/java/com/sensirion/libble/services/sensirion/shtc1/SHTC1HistoryService.java
@@ -12,6 +12,7 @@ import com.sensirion.libble.listeners.services.HumidityListener;
 import com.sensirion.libble.listeners.services.RHTListener;
 import com.sensirion.libble.listeners.services.TemperatureListener;
 import com.sensirion.libble.services.AbstractHistoryService;
+import com.sensirion.libble.services.BleServiceSynchronizationPriority;
 import com.sensirion.libble.utils.HumidityUnit;
 import com.sensirion.libble.utils.RHTDataPoint;
 import com.sensirion.libble.utils.TemperatureUnit;
@@ -931,5 +932,14 @@ public class SHTC1HistoryService extends AbstractHistoryService {
             default:
                 return null;
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public BleServiceSynchronizationPriority getServiceSynchronizationPriority(){
+        return BleServiceSynchronizationPriority.NORMAL_PRIORITY;
     }
 }

--- a/lib/src/main/java/com/sensirion/libble/services/sensirion/shtc1/SHTC1RHTService.java
+++ b/lib/src/main/java/com/sensirion/libble/services/sensirion/shtc1/SHTC1RHTService.java
@@ -8,6 +8,7 @@ import android.util.Log;
 
 import com.sensirion.libble.devices.Peripheral;
 import com.sensirion.libble.services.AbstractRHTService;
+import com.sensirion.libble.services.BleServiceSynchronizationPriority;
 import com.sensirion.libble.utils.RHTDataPoint;
 
 import java.nio.ByteBuffer;
@@ -108,5 +109,14 @@ public class SHTC1RHTService extends AbstractRHTService {
         }
         Log.e(TAG, "getLastDataPoint -> Service is not synchronized yet. (HINT -> Call synchronizeService() first)");
         return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public BleServiceSynchronizationPriority getServiceSynchronizationPriority(){
+        return BleServiceSynchronizationPriority.LOW_PRIORITY;
     }
 }

--- a/lib/src/main/java/com/sensirion/libble/services/sensirion/smartgadget/AbstractSmartgadgetRHTService.java
+++ b/lib/src/main/java/com/sensirion/libble/services/sensirion/smartgadget/AbstractSmartgadgetRHTService.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import com.sensirion.libble.devices.Peripheral;
 import com.sensirion.libble.listeners.NotificationListener;
 import com.sensirion.libble.listeners.services.RHTListener;
+import com.sensirion.libble.services.BleServiceSynchronizationPriority;
 
 abstract class AbstractSmartgadgetRHTService<ListenerType extends NotificationListener> extends AbstractSmartgadgetService<ListenerType> {
 
@@ -37,5 +38,14 @@ abstract class AbstractSmartgadgetRHTService<ListenerType extends NotificationLi
             SmartgadgetRHTNotificationCenter.getInstance().unregisterDownloadListener((RHTListener) listener, mPeripheral);
         }
         return super.unregisterNotificationListener(listener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public BleServiceSynchronizationPriority getServiceSynchronizationPriority(){
+        return BleServiceSynchronizationPriority.LOW_PRIORITY;
     }
 }

--- a/lib/src/main/java/com/sensirion/libble/services/sensirion/smartgadget/SmartgadgetHistoryService.java
+++ b/lib/src/main/java/com/sensirion/libble/services/sensirion/smartgadget/SmartgadgetHistoryService.java
@@ -8,6 +8,7 @@ import android.util.Log;
 
 import com.sensirion.libble.devices.Peripheral;
 import com.sensirion.libble.services.AbstractHistoryService;
+import com.sensirion.libble.services.BleServiceSynchronizationPriority;
 import com.sensirion.libble.utils.LittleEndianExtractor;
 
 import java.util.concurrent.Executors;
@@ -457,5 +458,14 @@ public class SmartgadgetHistoryService extends AbstractHistoryService {
     @Nullable
     public Long getNewestTimestampMs() {
         return mNewestSampleTimestampMs;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public BleServiceSynchronizationPriority getServiceSynchronizationPriority(){
+        return BleServiceSynchronizationPriority.HIGH_PRIORITY;
     }
 }

--- a/lib/src/main/java/com/sensirion/libble/services/ti/SensorTagRHTService.java
+++ b/lib/src/main/java/com/sensirion/libble/services/ti/SensorTagRHTService.java
@@ -8,6 +8,7 @@ import android.util.Log;
 
 import com.sensirion.libble.devices.Peripheral;
 import com.sensirion.libble.services.AbstractRHTService;
+import com.sensirion.libble.services.BleServiceSynchronizationPriority;
 import com.sensirion.libble.utils.LittleEndianExtractor;
 import com.sensirion.libble.utils.RHTDataPoint;
 
@@ -100,5 +101,14 @@ public class SensorTagRHTService extends AbstractRHTService {
     @NonNull
     public String getSensorName() {
         return SENSOR_NAME;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public BleServiceSynchronizationPriority getServiceSynchronizationPriority(){
+        return BleServiceSynchronizationPriority.LOW_PRIORITY;
     }
 }


### PR DESCRIPTION
- This commit adds a way of synchronizing bluetooth services in an
  specific order.
